### PR TITLE
sfdlib→sfdLib

### DIFF
--- a/sources/gen-sources.sh
+++ b/sources/gen-sources.sh
@@ -15,7 +15,7 @@ do
 	italic="Italic"
 	python3 -m sfdnormalize -k Copyright ./"$source" "$source"_out
 	mv ./"$source"_out ./"$source"
-	python3 -m sfdlib --ufo-kerning --ufo-anchors $source $UFO_DIR/${base%.*}.ufo
+	python3 -m sfdLib --ufo-kerning --ufo-anchors $source $UFO_DIR/${base%.*}.ufo
 	if test "${base#*$italic}" != "$base"
 	then
 		cp misc/features${italic}.fea $UFO_DIR/${base%.*}.ufo/features.fea


### PR DESCRIPTION
in build script…sorry…pip really should not allow you to lowercase it when you set it up if it is going to force the uppercase on install time :dizzy_face: 